### PR TITLE
Move co-authored-by to end of messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,6 +178,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79255cf29f5711995ddf9ec261b4057b1deb34e66c90656c201e41376872c544"
+dependencies = [
+ "indoc-impl",
+ "proc-macro-hack",
+]
+
+[[package]]
+name = "indoc-impl"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54554010aa3d17754e484005ea0022f1c93839aabc627c2c55f3d7b47206134c"
+dependencies = [
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "unindent",
+]
+
+[[package]]
 name = "itertools"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -308,6 +331,7 @@ version = "2.82.0"
 dependencies = [
  "enum-iterator",
  "git2",
+ "indoc",
  "itertools",
  "pb-hook-test-helper",
  "pretty_assertions",
@@ -409,6 +433,12 @@ dependencies = [
  "difference",
  "output_vt100",
 ]
+
+[[package]]
+name = "proc-macro-hack"
+version = "0.5.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e0456befd48169b9f13ef0f0ad46d492cf9d2dbb918bcf38e01eed4ce3ec5e4"
 
 [[package]]
 name = "proc-macro2"
@@ -618,6 +648,12 @@ name = "unicode-xid"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
+
+[[package]]
+name = "unindent"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63f18aa3b0e35fed5a0048f029558b1518095ffe2a0a31fb87c93dece93a4993"
 
 [[package]]
 name = "url"

--- a/pb-commit-message-lints/Cargo.toml
+++ b/pb-commit-message-lints/Cargo.toml
@@ -25,3 +25,4 @@ serde_derive = "1.0.110"
 tempfile = "3"
 pretty_assertions = "0.6.1"
 pb-hook-test-helper = { path = "../pb-hook-test-helper" }
+indoc = "0.3"

--- a/pb-commit-message-lints/src/lints/lib/commit_message.rs
+++ b/pb-commit-message-lints/src/lints/lib/commit_message.rs
@@ -1,6 +1,5 @@
 use regex::Regex;
-use std::fmt::Display;
-use std::{convert::TryFrom, fs::File, io::Read, path::PathBuf};
+use std::{convert::TryFrom, fmt::Display, fs::File, io::Read, path::PathBuf};
 
 use crate::errors::PbCommitMessageLintsError;
 
@@ -14,7 +13,10 @@ impl CommitMessage {
     #[must_use]
     pub fn new(contents: String) -> CommitMessage {
         let comment_char = "#".into();
-        CommitMessage { contents, comment_char }
+        CommitMessage {
+            contents,
+            comment_char,
+        }
     }
 
     pub fn matches_pattern(&self, re: &Regex) -> bool {
@@ -29,6 +31,7 @@ impl CommitMessage {
             .collect::<Vec<_>>()
     }
 
+    #[must_use]
     pub fn add_trailer(&self, trailer: &str) -> Self {
         let (body, trailing_comment) = self.message_parts();
 
@@ -104,7 +107,7 @@ mod test_commit_message {
                 Another: Trailer
                 "
             )
-            .into()
+            .into(),
         );
 
         assert_eq!(vec!["Another: Trailer"], commit.get_trailer("Another"));
@@ -158,7 +161,7 @@ mod test_commit_message {
                     Anything: Some Trailer
                     "
                 )
-                .into()
+                .into(),
             ),
             CommitMessage::new(
                 indoc!(
@@ -167,8 +170,9 @@ mod test_commit_message {
                     With a description.
                     "
                 )
-                .into()
-            ).add_trailer("Anything: Some Trailer")
+                .into(),
+            )
+            .add_trailer("Anything: Some Trailer")
         );
     }
 
@@ -184,11 +188,10 @@ mod test_commit_message {
                     # Comments about writing a commit message
                     "
                 )
-                .into()
+                .into(),
             ),
-            CommitMessage::new(
-                "# Comments about writing a commit message\n".into()
-            ).add_trailer("Trailer: Title")
+            CommitMessage::new("# Comments about writing a commit message\n".into())
+                .add_trailer("Trailer: Title")
         );
     }
 
@@ -204,7 +207,7 @@ mod test_commit_message {
                     # Comment about committing
                     "
                 )
-                .into()
+                .into(),
             ),
             CommitMessage::new(
                 indoc!(
@@ -212,8 +215,9 @@ mod test_commit_message {
 
                     # Comment about committing"
                 )
-                .into()
-            ).add_trailer("Trailer: Title")
+                .into(),
+            )
+            .add_trailer("Trailer: Title")
         );
     }
 
@@ -234,7 +238,7 @@ mod test_commit_message {
                     # Trailing comment line 2
                     "
                 )
-                .into()
+                .into(),
             ),
             CommitMessage::new(
                 indoc!(
@@ -247,8 +251,9 @@ mod test_commit_message {
                     # Trailing comment line 1
                     # Trailing comment line 2"
                 )
-                .into()
-            ).add_trailer("Trailer: Title")
+                .into(),
+            )
+            .add_trailer("Trailer: Title")
         );
     }
 }

--- a/pb-commit-message-lints/src/lints/lib/commit_message.rs
+++ b/pb-commit-message-lints/src/lints/lib/commit_message.rs
@@ -1,0 +1,101 @@
+use regex::Regex;
+use std::fmt::Display;
+
+use std::{convert::TryFrom, fs::File, io::Read, path::PathBuf};
+
+use crate::errors::PbCommitMessageLintsError;
+
+pub struct CommitMessage {
+    contents: String,
+}
+
+impl CommitMessage {
+    #[must_use]
+    pub fn new(contents: String) -> CommitMessage {
+        CommitMessage { contents }
+    }
+
+    pub fn matches_pattern(&self, re: &Regex) -> bool {
+        re.is_match(&self.contents)
+    }
+
+    #[must_use]
+    pub fn get_trailer(&self, trailer: &str) -> Vec<&str> {
+        self.contents
+            .lines()
+            .filter(|line: &&str| CommitMessage::line_has_trailer(trailer, line))
+            .collect::<Vec<_>>()
+    }
+
+    fn line_has_trailer(trailer: &str, line: &str) -> bool {
+        line.starts_with(&format!("{}:", trailer))
+    }
+}
+
+impl TryFrom<PathBuf> for CommitMessage {
+    type Error = PbCommitMessageLintsError;
+
+    fn try_from(value: PathBuf) -> Result<Self, Self::Error> {
+        let mut file = File::open(value)?;
+        let mut buffer = String::new();
+
+        file.read_to_string(&mut buffer)
+            .map_err(PbCommitMessageLintsError::from)
+            .map(move |_| CommitMessage::new(buffer))
+    }
+}
+
+impl Display for CommitMessage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.contents)
+    }
+}
+
+#[cfg(test)]
+mod test_commit_message {
+    use pretty_assertions::assert_eq;
+    use regex::Regex;
+
+    use crate::lints::CommitMessage;
+
+    #[test]
+    fn with_trailers() {
+        let commit = CommitMessage::new(
+            r#"Some Commit Message
+
+Anything: Some Trailer
+Anything: Some Trailer
+Another: Trailer
+"#
+            .into(),
+        );
+
+        assert_eq!(vec!["Another: Trailer"], commit.get_trailer("Another"));
+        assert_eq!(
+            vec!["Anything: Some Trailer", "Anything: Some Trailer"],
+            commit.get_trailer("Anything")
+        )
+    }
+
+    #[test]
+    fn regex_matching() {
+        let commit = CommitMessage::new(
+            r#"Some Commit Message
+
+Anything: Some Trailer
+Anything: Some Trailer
+Another: Trailer
+"#
+            .into(),
+        );
+
+        assert_eq!(
+            true,
+            commit.matches_pattern(&Regex::new("[AB]nything:").unwrap())
+        );
+        assert_eq!(
+            false,
+            commit.matches_pattern(&Regex::new("N[oO]thing:").unwrap())
+        );
+    }
+}

--- a/pb-commit-message-lints/src/lints/lib/commit_message.rs
+++ b/pb-commit-message-lints/src/lints/lib/commit_message.rs
@@ -1,6 +1,5 @@
 use regex::Regex;
 use std::fmt::Display;
-
 use std::{convert::TryFrom, fs::File, io::Read, path::PathBuf};
 
 use crate::errors::PbCommitMessageLintsError;
@@ -56,18 +55,22 @@ mod test_commit_message {
     use pretty_assertions::assert_eq;
     use regex::Regex;
 
-    use crate::lints::CommitMessage;
+    use indoc::indoc;
+
+    use super::CommitMessage;
 
     #[test]
     fn with_trailers() {
         let commit = CommitMessage::new(
-            r#"Some Commit Message
+            indoc!(
+                "Some Commit Message
 
-Anything: Some Trailer
-Anything: Some Trailer
-Another: Trailer
-"#
-            .into(),
+                Anything: Some Trailer
+                Anything: Some Trailer
+                Another: Trailer
+                "
+            )
+            .into()
         );
 
         assert_eq!(vec!["Another: Trailer"], commit.get_trailer("Another"));
@@ -80,12 +83,14 @@ Another: Trailer
     #[test]
     fn regex_matching() {
         let commit = CommitMessage::new(
-            r#"Some Commit Message
+            indoc!(
+                "Some Commit Message
 
-Anything: Some Trailer
-Anything: Some Trailer
-Another: Trailer
-"#
+                Anything: Some Trailer
+                Anything: Some Trailer
+                Another: Trailer
+                "
+            )
             .into(),
         );
 

--- a/pb-commit-message-lints/src/lints/lib/mod.rs
+++ b/pb-commit-message-lints/src/lints/lib/mod.rs
@@ -1,0 +1,3 @@
+pub mod commit_message;
+
+pub use commit_message::CommitMessage;

--- a/pb-commit-message-lints/src/lints/lib/mod.rs
+++ b/pb-commit-message-lints/src/lints/lib/mod.rs
@@ -1,3 +1,3 @@
-pub mod commit_message;
+mod commit_message;
 
 pub use commit_message::CommitMessage;

--- a/pb-commit-msg/src/main.rs
+++ b/pb-commit-msg/src/main.rs
@@ -8,7 +8,7 @@ use crate::PbCommitMessageError::PbCommitMessageLints;
 use pb_commit_message_lints::{
     errors::PbCommitMessageLintsError,
     external::vcs::Git2,
-    lints::{get_lint_configuration, lint, CommitMessage, LintCode, LintProblem},
+    lints::{get_lint_configuration, lint, lib::CommitMessage, LintCode, LintProblem},
 };
 use std::{
     convert::TryFrom,

--- a/pb-commit-msg/src/main.rs
+++ b/pb-commit-msg/src/main.rs
@@ -8,7 +8,7 @@ use crate::PbCommitMessageError::PbCommitMessageLints;
 use pb_commit_message_lints::{
     errors::PbCommitMessageLintsError,
     external::vcs::Git2,
-    lints::{get_lint_configuration, lint, lib::CommitMessage, LintCode, LintProblem},
+    lints::{get_lint_configuration, lib::CommitMessage, lint, LintCode, LintProblem},
 };
 use std::{
     convert::TryFrom,

--- a/pb-prepare-commit-msg/src/main.rs
+++ b/pb-prepare-commit-msg/src/main.rs
@@ -8,7 +8,7 @@ use pb_commit_message_lints::{
     author::{entities::Author, vcs::get_coauthor_configuration},
     errors::PbCommitMessageLintsError,
     external::vcs::Git2,
-    lints::CommitMessage,
+    lints::lib::CommitMessage,
 };
 use std::{
     convert::TryFrom,

--- a/pb-prepare-commit-msg/src/main.rs
+++ b/pb-prepare-commit-msg/src/main.rs
@@ -83,7 +83,6 @@ fn append_coauthors_to_commit_message(
     let path = String::from(commit_message_path.to_string_lossy());
     let commit_message = CommitMessage::try_from(commit_message_path.clone())?;
 
-
     let message = format!(
         "{}",
         authors

--- a/pb-prepare-commit-msg/tests/e2e_tags_authors.rs
+++ b/pb-prepare-commit-msg/tests/e2e_tags_authors.rs
@@ -42,11 +42,11 @@ In this commit message I have put a witty message"#
     let expected_stdout = "";
     let expected_stderr = r#""#;
     let expect_success = true;
-    let expected_commit_message = r#"Co-authored-by: Annie Example <test@example.com>
-Lorem Ipsum
+    let expected_commit_message = r#"Lorem Ipsum
 
 In this commit message I have put a witty message
 
+Co-authored-by: Annie Example <test@example.com>
 "#;
 
     assert_output(
@@ -93,11 +93,11 @@ In this commit message I have put a witty message"#
     let expected_stdout = "";
     let expected_stderr = r#""#;
     let expect_success = true;
-    let expected_commit_message = r#"Co-authored-by: Annie Example <test@example.com>
-A different mesage
+    let expected_commit_message = r#"A different mesage
 
 In this commit message I have put a witty message
 
+Co-authored-by: Annie Example <test@example.com>
 "#;
 
     assert_output(
@@ -145,12 +145,13 @@ In this commit message I have put a witty message"#
     let expected_stdout = "";
     let expected_stderr = r#""#;
     let expect_success = true;
-    let expected_commit_message = r#"Co-authored-by: Joseph Bloggs <joe@example.com>
-Co-authored-by: Annie Example <annie@example.com>
-A different mesage
+    let expected_commit_message = r#"A different mesage
 
 In this commit message I have put a witty message
 
+Co-authored-by: Joseph Bloggs <joe@example.com>
+
+Co-authored-by: Annie Example <annie@example.com>
 "#;
 
     assert_output(


### PR DESCRIPTION
I find having them at the start gets in the way of the main title for the commit.

If there is any requirement to be able to have them at the start then I can look at adding a config option.